### PR TITLE
Update run.R so that cluster is treated as a string in future::plan

### DIFF
--- a/Docker-psock/run.R
+++ b/Docker-psock/run.R
@@ -14,6 +14,6 @@ cl <- future::makeClusterPSOCK( # nolint
   )
 )
 
-future::plan(cluster, workers = cl)
+future::plan("cluster", workers = cl)
 load_mtcars_example()
 make(my_plan, parallelism = "future")


### PR DESCRIPTION
Needs quotes or it tries to find a `cluster` object

# Summary

Running the example and was stymied by the error in future::plan looking for `cluster`


# Checklist

- [ X] I have read this repository's [code of conduct](https://github.com/wlandau/drake-examples/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X ] I certify that this pull request respects all copyright, licensing, and ownership agreements among all parties involved.
- [X ] When compressed into a `.zip` file, each new or changed project is smaller than 100 MB.
- [ ] If this is a new example project, it includes
    - [ ] A `COPYRIGHT.md` file with the names of the owners.
    - [ ] A `LICENSE.md` file with a [valid and appropriate open source license](https://choosealicense.com/).
    - [ ] A `README.md` file to tell new users about the purpose of the example and how to run it.
    - [ ] A `CONTRIBUTING.md` file with any additional requirements or restrictions for contributing to the project.
- [X ] This pull request is ready for review.
- [ X] I think this pull request is ready to merge.
