### PR TITLE
Changes to track deprecate-lme in drake repo

### DIFF
--- a/main/R/setup.R
+++ b/main/R/setup.R
@@ -2,8 +2,8 @@
 # This example requires packages forcats, readxl, and rmarkdown,
 # but you do not need to load them here.
 library(drake)
-library(dplyr)
-library(ggplot2)
+require(dplyr)
+require(ggplot2)
 pkgconfig::set_config("drake::strings_in_dots" = "literals") # New file API
 
 # Your custom code is a bunch of functions.


### PR DESCRIPTION
Per @wlandau instructions in https://github.com/ropensci/drake/issues/605

# Summary

Changes recommended for `load_main_example()` deprecation in drake.

# Related GitHub issues and pull requests

- Ref: https://github.com/ropensci/drake/issues/605

# Checklist

- [X] I have read this repository's [code of conduct](https://github.com/wlandau/drake-examples/blob/master/CONDUCT.md), and I agree to follow its rules.
- [X] I certify that this pull request respects all copyright, licensing, and ownership agreements among all parties involved.
- [X] When compressed into a `.zip` file, each new or changed project is smaller than 100 MB.
- [ ] If this is a new example project, it includes
    - [ ] A `COPYRIGHT.md` file with the names of the owners.
    - [ ] A `LICENSE.md` file with a [valid and appropriate open source license](https://choosealicense.com/).
    - [ ] A `README.md` file to tell new users about the purpose of the example and how to run it.
    - [ ] A `CONTRIBUTING.md` file with any additional requirements or restrictions for contributing to the project.
- [X] This pull request is ready for review.
- [X] I think this pull request is ready to merge.