### PR TITLE
update links to main example as walkthrough

### DIFF
--- a/main/README.md
+++ b/main/README.md
@@ -1,1 +1,1 @@
-This is the example from [this chapter of the user manual](https://ropenscilabs.github.io/drake-manual/intro.html). Originally written by [Kirill Müller](https://github.com/krlmlr).
+This is the example from [this chapter of the user manual](https://ropenscilabs.github.io/drake-manual/walkthrough.html). Originally written by [Kirill Müller](https://github.com/krlmlr).

--- a/main/make.R
+++ b/main/make.R
@@ -1,4 +1,4 @@
-# Walkthrough: https://ropenscilabs.github.io/drake-manual/intro.html
+# Walkthrough: https://ropenscilabs.github.io/drake-manual/walkthrough.html
 # Download the code: drake_example("main") # nolint
 
 # Load your packages and supporting functions into your session.

--- a/main/report.Rmd
+++ b/main/report.Rmd
@@ -15,5 +15,5 @@ readd(hist)
 
 More:
 
-- Walkthrough: [this chapter of the user manual](https://ropenscilabs.github.io/drake-manual/intro.html)
+- Walkthrough: [this chapter of the user manual](https://ropenscilabs.github.io/drake-manual/walkthrough.html)
 - Code: `drake_example("main")`


### PR DESCRIPTION
# Summary

Updates to the links in the `main` example. The current [link](https://ropenscilabs.github.io/drake-manual/intro.html) results in a 404 😢. 

# Related GitHub issues and pull requests

I didn't see any.

# Checklist

- [x] I have read this repository's [code of conduct](https://github.com/wlandau/drake-examples/blob/master/CONDUCT.md), and I agree to follow its rules.
- [x] I certify that this pull request respects all copyright, licensing, and ownership agreements among all parties involved.
- [x] When compressed into a `.zip` file, each new or changed project is smaller than 100 MB.
- [ ] If this is a new example project, it includes
    - [ ] A `COPYRIGHT.md` file with the names of the owners.
    - [ ] A `LICENSE.md` file with a [valid and appropriate open source license](https://choosealicense.com/).
    - [ ] A `README.md` file to tell new users about the purpose of the example and how to run it.
    - [ ] A `CONTRIBUTING.md` file with any additional requirements or restrictions for contributing to the project.
- [x] This pull request is ready for review.
- [x] I think this pull request is ready to merge.